### PR TITLE
remove noexcept specifier from Context::pollEvents()

### DIFF
--- a/include/limitless/core/context.hpp
+++ b/include/limitless/core/context.hpp
@@ -47,7 +47,7 @@ namespace Limitless {
 
         void makeCurrent() const noexcept;
         void swapBuffers() const noexcept;
-        void pollEvents() const noexcept;
+        void pollEvents() const;
 
         void setSwapInterval(GLuint interval) const noexcept;
         void setWindowShouldClose(bool value) const noexcept;

--- a/src/limitless/core/context.cpp
+++ b/src/limitless/core/context.cpp
@@ -108,7 +108,7 @@ void Context::setFullscreen(bool value) noexcept {
     }
 }
 
-void Context::pollEvents() const noexcept {
+void Context::pollEvents() const {
     glfwPollEvents();
 }
 


### PR DESCRIPTION
This method calls glfwPollEvents(), which will call assigned GLFW callback functions, which in turn can and will throw exceptions, crashing the application with no survivors with std::terminate.