### PR TITLE
[FIX] missing vertex.glsl in skybox.vs

### DIFF
--- a/shaders/pipeline/deferred/skybox.vs
+++ b/shaders/pipeline/deferred/skybox.vs
@@ -1,6 +1,7 @@
 Limitless::GLSL_VERSION
 Limitless::Extensions
 
+#include "../interface_block/vertex.glsl"
 #include "../scene.glsl"
 
 layout (location = 0) in vec3 vertex_position;


### PR DESCRIPTION
Input block `_vertex_data' is not an output of the previous stage