### PR TITLE
set actual framebuffer size after context window creation

### DIFF
--- a/src/limitless/core/context.cpp
+++ b/src/limitless/core/context.cpp
@@ -6,12 +6,12 @@ using namespace Limitless;
 
 Context::Context(
     const std::string& title,
-    glm::uvec2 size,
+    glm::uvec2 _size,
     const Context* shared,
     const WindowHints& hints
 ) : ContextInitializer()
   , ContextState()
-  , size {size} {
+  , size {_size} {
     // sets window hints for creation
     for (const auto& [hint, value] : hints) {
         glfwWindowHint(static_cast<int>(hint), value);
@@ -22,6 +22,13 @@ Context::Context(
     if (!window) {
         throw context_error {"Failed to create window"};
     }
+
+    // The created window, framebuffer and context may differ from what you requested.
+    int framebuffer_width = 0;
+    int framebuffer_height = 0;
+    glfwGetFramebufferSize(window, &framebuffer_width, &framebuffer_height);
+
+    size = glm::uvec2(framebuffer_width, framebuffer_height);
 
     if (!glew_inited) {
         makeCurrent();


### PR DESCRIPTION
from [GLFW docs](https://www.glfw.org/docs/latest/group__window.html#ga3555a418df92ad53f917597fe2f64aeb)
>The created window, framebuffer and context may differ from what you requested, as not all parameters and hints are [hard constraints](https://www.glfw.org/docs/latest/window_guide.html#window_hints_hard). This includes the size of the window, especially for full screen windows. To query the actual attributes of the created window, framebuffer and context, see [glfwGetWindowAttrib](https://www.glfw.org/docs/latest/group__window.html#gacccb29947ea4b16860ebef42c2cb9337), [glfwGetWindowSize](https://www.glfw.org/docs/latest/group__window.html#gaeea7cbc03373a41fb51cfbf9f2a5d4c6) and [glfwGetFramebufferSize](https://www.glfw.org/docs/latest/group__window.html#ga0e2637a4161afb283f5300c7f94785c9).